### PR TITLE
Add jupyterview

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 ## Web
 
 - [vtk-js](https://github.com/Kitware/vtk-js) - Visualization Toolkit for the Web
+- [jupyterview](https://github.com/trungleduc/jupyterview) - VTK Data visualization extension for JupyterLab
 
 ## Higher-level interfaces in Python
 


### PR DESCRIPTION
## What is this VTK tool?
**jupyterview** is an extension that adds the `VTK` data visualization capability to JupyterLab.

Powered by Kitware's `vtk.js` and `itk-wasm` library, **jupyterview** is a pure frontend extension, it does not require any kernel to operate and fully supports the Real-Time Collaboration feature of JupyterLab.

**jupyterview** is fully compatible with `jupyterlite`, it is available online at [jupyterview demo link](https://trungleduc.github.io/jupyterview).


![vtu](https://user-images.githubusercontent.com/4451292/157323037-f0d8149c-410b-483b-812a-3a4e3d524552.gif)

## What's the difference between this VTK tool and similar ones?

Enumerate comparisons.

--

Anyone who agrees with this pull request could submit an _Approve_ review to it.

<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

<!-- END doctoc generated TOC please keep comment here to allow auto update -->
