### PR TITLE
feat: add GitHub Pages gallery generated from README.md

### DIFF
--- a/.github/workflows/awesome_bot.yaml
+++ b/.github/workflows/awesome_bot.yaml
@@ -21,4 +21,6 @@ jobs:
           ruby-version: 2.6.10
           bundler-cache: true
       - name: Checks
-        run: bundle exec awesome_bot --allow-redirect --request-delay 1 --white-list "https://github.com/sindresorhus/awesome/blob/main/awesome.md,https://upload.wikimedia.org" README.md
+        # tkoyama010.github.io is white listed because the gallery only exists
+        # once GitHub Pages has published it from the default branch.
+        run: bundle exec awesome_bot --allow-redirect --request-delay 1 --white-list "https://github.com/sindresorhus/awesome/blob/main/awesome.md,https://upload.wikimedia.org,https://tkoyama010.github.io" README.md

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: ["*"]
+    types: [opened, reopened, synchronize, closed]
   workflow_dispatch:
 permissions: {}
 concurrency:
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   build-site:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -24,23 +25,80 @@ jobs:
           python-version: "3.13"
       - name: Build the gallery
         run: uv run python build_gallery.py --output _site
+      # Downloadable from the run summary. This is how reviewers preview a pull
+      # request opened from a fork, which cannot deploy anywhere.
       - name: Upload the site
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
+          name: gallery-preview
           path: _site
+          if-no-files-found: error
   deploy:
-    # Pages can only be published from the default branch, so every other ref
-    # stops after the build job above.
+    # The production site. Previews live in pr-preview/ on the same branch, so
+    # they are excluded from the cleanup of removed files.
     if: github.ref == 'refs/heads/main'
     needs: build-site
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      pages: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      contents: write
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - name: Download the site
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: gallery-preview
+          path: _site
+      - name: Publish to gh-pages
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f
+        with:
+          branch: gh-pages
+          folder: _site
+          clean-exclude: pr-preview/
+          commit-message: "chore: publish the gallery for ${{ github.sha }}"
+  preview:
+    # A pull request from a branch in this repository gets its own preview URL,
+    # posted as a comment. A pull request from a fork cannot: its token is read
+    # only, so the gallery-preview artifact above is the fallback.
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.action != 'closed'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    needs: build-site
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - name: Download the site
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: gallery-preview
+          path: _site
+      - name: Deploy the preview
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9
+        with:
+          source-dir: _site
+          action: deploy
+  preview-cleanup:
+    # Removes pr-preview/pr-N/ once the pull request is closed or merged.
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.action == 'closed'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - name: Remove the preview
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9
+        with:
+          action: remove

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -33,6 +33,8 @@ jobs:
           name: gallery-preview
           path: _site
           if-no-files-found: error
+          # Without this the generated .nojekyll marker is dropped.
+          include-hidden-files: true
   deploy:
     # The production site. Previews live in pr-preview/ on the same branch, so
     # they are excluded from the cleanup of removed files.

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,46 @@
+name: Pages
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["*"]
+  workflow_dispatch:
+permissions: {}
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.13"
+      - name: Build the gallery
+        run: python build_gallery.py --output _site
+      - name: Upload the site
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
+        with:
+          path: _site
+  deploy:
+    # Pages can only be published from the default branch, so pull requests
+    # stop after the build job above.
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -10,7 +10,7 @@ concurrency:
   group: pages-${{ github.ref }}
   cancel-in-progress: false
 jobs:
-  build:
+  build-site:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,21 +18,21 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
         with:
           python-version: "3.13"
       - name: Build the gallery
-        run: python build_gallery.py --output _site
+        run: uv run python build_gallery.py --output _site
       - name: Upload the site
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: _site
   deploy:
-    # Pages can only be published from the default branch, so pull requests
-    # stop after the build job above.
-    if: github.event_name != 'pull_request'
-    needs: build
+    # Pages can only be published from the default branch, so every other ref
+    # stops after the build job above.
+    if: github.ref == 'refs/heads/main'
+    needs: build-site
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_site/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-3.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 ![All Contributors](https://img.shields.io/github/all-contributors/tkoyama010/awesome-vtk?color=ee8449)
+[![GitHub Pages](https://img.shields.io/github/deployments/tkoyama010/awesome-vtk/github-pages?label=github%20pages)](https://tkoyama010.github.io/awesome-vtk/)
 
 <p align="center">
     <a href="https://vtk.org/">
@@ -12,8 +13,6 @@
 > The Visualization Toolkit (VTK) is open source software for manipulating and displaying scientific data. It comes with state-of-the-art tools for 3D rendering, a suite of widgets for 3D interaction, and extensive 2D plotting capability.
 
 This list is a collection of tools, projects, images, and resources conforming to the [Awesome Manifesto](https://github.com/sindresorhus/awesome/blob/main/awesome.md)
-
-Browse it as a searchable gallery: **[tkoyama010.github.io/awesome-vtk](https://tkoyama010.github.io/awesome-vtk/)**
 
 Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 This list is a collection of tools, projects, images, and resources conforming to the [Awesome Manifesto](https://github.com/sindresorhus/awesome/blob/main/awesome.md)
 
+Browse it as a searchable gallery: **[tkoyama010.github.io/awesome-vtk](https://tkoyama010.github.io/awesome-vtk/)**
+
 Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 
 ## Contents

--- a/build_gallery.py
+++ b/build_gallery.py
@@ -1,0 +1,210 @@
+"""Build a static GitHub Pages gallery from the entries listed in README.md."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import logging
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit
+
+logger = logging.getLogger(__name__)
+
+HEADING = re.compile(r"^##\s+(?P<title>.+?)\s*$")
+ENTRY = re.compile(
+    r"^-\s+\[(?P<name>[^\]]+)\]\((?P<url>[^)\s]+)\)"
+    r"(?:\s+-\s+(?P<description>.+?))?\s*$",
+)
+GITHUB_REPO = re.compile(
+    r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/#?]+)/?$",
+)
+NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+# The table of contents is generated from the headings below it, so its list
+# items are not gallery entries.
+IGNORED_SECTIONS = frozenset({"contents"})
+
+TEMPLATE_DIR = Path("site")
+ASSETS = ("style.css", "app.js")
+HUES = 360
+
+
+@dataclass(frozen=True)
+class Entry:
+    """A single link taken from the awesome list."""
+
+    name: str
+    url: str
+    description: str
+    category: str
+
+    @property
+    def host(self) -> str:
+        """Returns the host name of the link, without a ``www.`` prefix."""
+        return urlsplit(self.url).netloc.removeprefix("www.")
+
+    @property
+    def thumbnail(self) -> str:
+        """Returns a preview image URL, or an empty string when there is none."""
+        match = GITHUB_REPO.match(self.url)
+        if match is None:
+            return ""
+        return (
+            f"https://opengraph.githubassets.com/awesome-vtk/"
+            f"{match['owner']}/{match['repo']}"
+        )
+
+    @property
+    def initials(self) -> str:
+        """Returns the placeholder monogram shown when no preview image loads."""
+        return self.name[0].upper()
+
+    @property
+    def hue(self) -> int:
+        """Returns a stable hue used to tint the placeholder monogram."""
+        return sum(ord(character) for character in self.name) % HUES
+
+
+@dataclass(frozen=True)
+class Category:
+    """A README section together with the entries it contains."""
+
+    title: str
+    entries: tuple[Entry, ...]
+
+    @property
+    def slug(self) -> str:
+        """Returns an identifier usable in HTML attributes."""
+        return NON_ALNUM.sub("-", self.title.lower()).strip("-")
+
+
+def parse_readme(readme: Path) -> list[Category]:
+    """Collect the entries of every README section, keeping the file order."""
+    categories: list[Category] = []
+    title = ""
+    entries: list[Entry] = []
+
+    def flush() -> None:
+        if title and entries:
+            categories.append(Category(title=title, entries=tuple(entries)))
+
+    for line in readme.read_text(encoding="utf-8").splitlines():
+        heading = HEADING.match(line)
+        if heading is not None:
+            flush()
+            title = heading["title"]
+            entries = []
+            continue
+        if title.lower() in IGNORED_SECTIONS:
+            continue
+        entry = ENTRY.match(line)
+        if entry is not None:
+            entries.append(
+                Entry(
+                    name=entry["name"],
+                    url=entry["url"],
+                    description=entry["description"] or "",
+                    category=title,
+                ),
+            )
+    flush()
+    return categories
+
+
+def render_card(entry: Entry) -> str:
+    """Render a single gallery card."""
+    name = html.escape(entry.name)
+    description = html.escape(entry.description)
+    haystack = html.escape(f"{entry.name} {entry.description} {entry.category}".lower())
+    thumbnail = (
+        f'<img class="card__image" src="{html.escape(entry.thumbnail)}" alt="" '
+        f'loading="lazy" decoding="async" />'
+        if entry.thumbnail
+        else ""
+    )
+    return f"""      <article class="card" data-category="{html.escape(entry.category)}" data-search="{haystack}">
+        <a class="card__link" href="{html.escape(entry.url)}" target="_blank" rel="noopener noreferrer">
+          <div class="card__thumb" style="--hue: {entry.hue}">
+            <span class="card__monogram" aria-hidden="true">{html.escape(entry.initials)}</span>
+            {thumbnail}
+          </div>
+          <div class="card__body">
+            <h3 class="card__title">{name}</h3>
+            <p class="card__description">{description}</p>
+            <p class="card__meta">{html.escape(entry.host)}</p>
+          </div>
+        </a>
+      </article>"""  # noqa: E501
+
+
+def render_section(category: Category) -> str:
+    """Render one README section as a titled grid of cards."""
+    cards = "\n".join(render_card(entry) for entry in category.entries)
+    return f"""    <section class="section" id="{category.slug}" data-category="{html.escape(category.title)}">
+      <h2 class="section__title">
+        {html.escape(category.title)}
+        <span class="section__count">{len(category.entries)}</span>
+      </h2>
+      <div class="grid">
+{cards}
+      </div>
+    </section>"""  # noqa: E501
+
+
+def render_filters(categories: list[Category]) -> str:
+    """Render the category filter buttons."""
+    titles = ["all", *(category.title for category in categories)]
+    return "\n".join(
+        f'        <button class="chip{" chip--active" if index == 0 else ""}" '
+        f'type="button" data-filter="{html.escape(title)}">'
+        f"{html.escape('All' if index == 0 else title)}</button>"
+        for index, title in enumerate(titles)
+    )
+
+
+def render_page(template: str, categories: list[Category]) -> str:
+    """Fill the page template with the parsed list."""
+    total = sum(len(category.entries) for category in categories)
+    replacements = {
+        "{{FILTERS}}": render_filters(categories),
+        "{{SECTIONS}}": "\n".join(render_section(c) for c in categories),
+        "{{ENTRY_COUNT}}": str(total),
+        "{{CATEGORY_COUNT}}": str(len(categories)),
+    }
+    for placeholder, value in replacements.items():
+        template = template.replace(placeholder, value)
+    return template
+
+
+def build(readme: Path, template_dir: Path, output: Path) -> int:
+    """Write the site into ``output`` and return the number of entries."""
+    categories = parse_readme(readme)
+    page = render_page(
+        (template_dir / "index.html").read_text(encoding="utf-8"),
+        categories,
+    )
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "index.html").write_text(page, encoding="utf-8")
+    for asset in ASSETS:
+        shutil.copyfile(template_dir / asset, output / asset)
+    return sum(len(category.entries) for category in categories)
+
+
+def main() -> None:
+    """Parse the command line arguments and build the site."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--readme", type=Path, default=Path("README.md"))
+    parser.add_argument("--template-dir", type=Path, default=TEMPLATE_DIR)
+    parser.add_argument("--output", type=Path, default=Path("_site"))
+    arguments = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    total = build(arguments.readme, arguments.template_dir, arguments.output)
+    logger.info("Wrote %s with %d entries", arguments.output / "index.html", total)
+
+
+if __name__ == "__main__":
+    main()

--- a/build_gallery.py
+++ b/build_gallery.py
@@ -190,6 +190,9 @@ def build(readme: Path, template_dir: Path, output: Path) -> int:
     (output / "index.html").write_text(page, encoding="utf-8")
     for asset in ASSETS:
         shutil.copyfile(template_dir / asset, output / asset)
+    # The site is already built, so tell GitHub Pages not to run it through
+    # Jekyll on the way out.
+    (output / ".nojekyll").touch()
     return sum(len(category.entries) for category in categories)
 
 

--- a/site/app.js
+++ b/site/app.js
@@ -1,0 +1,80 @@
+// Client side search and category filtering for the Awesome VTK gallery.
+(function () {
+  "use strict";
+
+  var search = document.getElementById("search");
+  var chips = Array.prototype.slice.call(
+    document.querySelectorAll("#chips .chip"),
+  );
+  var sections = Array.prototype.slice.call(
+    document.querySelectorAll(".section"),
+  );
+  var empty = document.getElementById("empty");
+  var activeCategory = "all";
+
+  function apply() {
+    var query = search.value.trim().toLowerCase();
+    var visible = 0;
+
+    sections.forEach(function (section) {
+      var matchesCategory =
+        activeCategory === "all" ||
+        section.getAttribute("data-category") === activeCategory;
+      var shown = 0;
+
+      Array.prototype.forEach.call(
+        section.querySelectorAll(".card"),
+        function (card) {
+          var matches =
+            matchesCategory &&
+            (query === "" ||
+              card.getAttribute("data-search").indexOf(query) !== -1);
+          card.hidden = !matches;
+          if (matches) {
+            shown += 1;
+          }
+        },
+      );
+
+      section.hidden = shown === 0;
+      visible += shown;
+    });
+
+    empty.hidden = visible !== 0;
+  }
+
+  search.addEventListener("input", apply);
+
+  chips.forEach(function (chip) {
+    chip.addEventListener("click", function () {
+      activeCategory = chip.getAttribute("data-filter");
+      chips.forEach(function (other) {
+        other.classList.toggle("chip--active", other === chip);
+      });
+      apply();
+    });
+  });
+
+  // Preview images come from GitHub's Open Graph service, which rate limits
+  // bursts of requests. Retry once with a jittered delay, then drop the image
+  // so the coloured monogram underneath stays visible.
+  Array.prototype.forEach.call(
+    document.querySelectorAll(".card__image"),
+    function (image) {
+      var retried = false;
+      image.addEventListener("error", function () {
+        if (retried) {
+          image.remove();
+          return;
+        }
+        retried = true;
+        var source = image.src;
+        window.setTimeout(function () {
+          image.src = source + "?retry=1";
+        }, 800 + Math.random() * 1600);
+      });
+    },
+  );
+
+  apply();
+})();

--- a/site/app.js
+++ b/site/app.js
@@ -69,9 +69,12 @@
         }
         retried = true;
         var source = image.src;
-        window.setTimeout(function () {
-          image.src = source + "?retry=1";
-        }, 800 + Math.random() * 1600);
+        window.setTimeout(
+          function () {
+            image.src = source + "?retry=1";
+          },
+          800 + Math.random() * 1600,
+        );
       });
     },
   );

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Awesome VTK — Gallery</title>
+    <meta
+      name="description"
+      content="A curated gallery of tools, projects and resources built with the Visualization Toolkit (VTK)."
+    />
+    <link
+      rel="icon"
+      href="https://upload.wikimedia.org/wikipedia/commons/7/76/Visualization_Toolkit_logo.svg"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <img
+        class="hero__logo"
+        src="https://upload.wikimedia.org/wikipedia/commons/7/76/Visualization_Toolkit_logo.svg"
+        alt="Visualization Toolkit logo"
+        width="120"
+        height="120"
+      />
+      <h1 class="hero__title">Awesome VTK</h1>
+      <p class="hero__tagline">
+        The Visualization Toolkit (VTK) is open source software for manipulating
+        and displaying scientific data. This gallery is a curated collection of
+        the tools, projects and resources built around it.
+      </p>
+      <p class="hero__stats">
+        <strong>{{ENTRY_COUNT}}</strong> entries in
+        <strong>{{CATEGORY_COUNT}}</strong> categories
+      </p>
+      <p class="hero__links">
+        <a class="button" href="https://github.com/tkoyama010/awesome-vtk"
+          >Repository</a
+        >
+        <a
+          class="button button--ghost"
+          href="https://github.com/tkoyama010/awesome-vtk/blob/main/CONTRIBUTING.md"
+          >Contribute</a
+        >
+      </p>
+    </header>
+
+    <nav class="toolbar" aria-label="Filter the gallery">
+      <label class="search">
+        <span class="search__label">Search the list</span>
+        <input
+          id="search"
+          class="search__input"
+          type="search"
+          placeholder="Search projects, e.g. python, medical, viewer…"
+          autocomplete="off"
+        />
+      </label>
+      <div class="chips" id="chips">{{FILTERS}}</div>
+    </nav>
+
+    <main class="content" id="content">
+      {{SECTIONS}}
+      <p class="empty" id="empty" hidden>No entry matches your search.</p>
+    </main>
+
+    <footer class="footer">
+      <p>
+        Generated from
+        <a href="https://github.com/tkoyama010/awesome-vtk/blob/main/README.md"
+          >README.md</a
+        >. Content released under
+        <a href="https://github.com/tkoyama010/awesome-vtk/blob/main/LICENSE"
+          >CC0 1.0</a
+        >.
+      </p>
+      <p>
+        Preview images are served by GitHub. Missing something? Open a pull
+        request.
+      </p>
+    </footer>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -24,8 +24,11 @@
         height="120"
       />
       <h1 class="hero__title">Awesome VTK</h1>
-      <!-- prettier-ignore -->
-      <p class="hero__tagline">The Visualization Toolkit (VTK) is open source software for manipulating and displaying scientific data. This gallery is a curated collection of the tools, projects and resources built around it.</p>
+      <p class="hero__tagline">
+        The Visualization Toolkit (VTK) is open source software for manipulating
+        and displaying scientific data. This gallery is a curated collection of
+        the tools, projects and resources built around it.
+      </p>
       <p class="hero__stats">
         <strong>{{ENTRY_COUNT}}</strong> entries in
         <strong>{{CATEGORY_COUNT}}</strong> categories

--- a/site/index.html
+++ b/site/index.html
@@ -24,11 +24,8 @@
         height="120"
       />
       <h1 class="hero__title">Awesome VTK</h1>
-      <p class="hero__tagline">
-        The Visualization Toolkit (VTK) is open source software for manipulating
-        and displaying scientific data. This gallery is a curated collection of
-        the tools, projects and resources built around it.
-      </p>
+      <!-- prettier-ignore -->
+      <p class="hero__tagline">The Visualization Toolkit (VTK) is open source software for manipulating and displaying scientific data. This gallery is a curated collection of the tools, projects and resources built around it.</p>
       <p class="hero__stats">
         <strong>{{ENTRY_COUNT}}</strong> entries in
         <strong>{{CATEGORY_COUNT}}</strong> categories

--- a/site/style.css
+++ b/site/style.css
@@ -1,0 +1,330 @@
+:root {
+  --bg: #f6f7f9;
+  --surface: #ffffff;
+  --border: #e2e5ea;
+  --text: #16191d;
+  --muted: #5d6673;
+  --accent: #0b6fb4;
+  --shadow: 0 1px 2px rgb(16 24 40 / 6%), 0 8px 24px rgb(16 24 40 / 6%);
+  --radius: 14px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0e1116;
+    --surface: #161b22;
+    --border: #2a313c;
+    --text: #e7ebf0;
+    --muted: #9aa5b1;
+    --accent: #6cb6f5;
+    --shadow: 0 1px 2px rgb(0 0 0 / 40%), 0 8px 24px rgb(0 0 0 / 30%);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    "Helvetica Neue",
+    "Noto Sans JP",
+    sans-serif;
+  line-height: 1.6;
+}
+
+a {
+  color: var(--accent);
+}
+
+/* Hero */
+
+.hero {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 3.5rem 1.25rem 2rem;
+  text-align: center;
+}
+
+.hero__logo {
+  width: 110px;
+  height: auto;
+}
+
+.hero__title {
+  margin: 0.75rem 0 0;
+  font-size: clamp(2.2rem, 6vw, 3.2rem);
+  letter-spacing: -0.02em;
+}
+
+.hero__tagline {
+  margin: 0.75rem auto 0;
+  max-width: 60ch;
+  color: var(--muted);
+}
+
+.hero__stats {
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.hero__links {
+  display: flex;
+  gap: 0.6rem;
+  justify-content: center;
+  margin: 1.5rem 0 0;
+}
+
+.button {
+  display: inline-block;
+  padding: 0.55rem 1.1rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--bg);
+  font-weight: 600;
+  font-size: 0.9rem;
+  text-decoration: none;
+}
+
+.button--ghost {
+  border-color: var(--border);
+  background: var(--surface);
+  color: var(--text);
+}
+
+.button:hover {
+  filter: brightness(1.07);
+}
+
+/* Toolbar */
+
+.toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  padding: 0.9rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.search {
+  display: block;
+  max-width: 620px;
+  margin: 0 auto;
+}
+
+.search__label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+}
+
+.search__input {
+  width: 100%;
+  padding: 0.7rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+}
+
+.search__input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  justify-content: center;
+  max-width: 900px;
+  margin: 0.8rem auto 0;
+}
+
+.chip {
+  padding: 0.3rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.chip:hover {
+  color: var(--text);
+}
+
+.chip--active {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--bg);
+  font-weight: 600;
+}
+
+/* Sections and cards */
+
+.content {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+}
+
+.section {
+  margin-bottom: 2.5rem;
+  scroll-margin-top: 8rem;
+}
+
+.section[hidden] {
+  display: none;
+}
+
+.section__title {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0 0 1rem;
+  font-size: 1.35rem;
+}
+
+.section__count {
+  padding: 0.05rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(270px, 1fr));
+  gap: 1.1rem;
+}
+
+.card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  overflow: hidden;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow);
+}
+
+.card[hidden] {
+  display: none;
+}
+
+.card__link {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  color: inherit;
+  text-decoration: none;
+}
+
+.card__thumb {
+  position: relative;
+  aspect-ratio: 2 / 1;
+  background: linear-gradient(
+    135deg,
+    hsl(var(--hue, 210) 55% 42%),
+    hsl(calc(var(--hue, 210) + 40) 60% 55%)
+  );
+}
+
+.card__monogram {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: #ffffff;
+  font-size: 2.6rem;
+  font-weight: 700;
+}
+
+.card__image {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.card__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  padding: 0.9rem 1rem 1rem;
+}
+
+.card__title {
+  margin: 0 0 0.35rem;
+  font-size: 1.02rem;
+}
+
+.card__description {
+  flex: 1;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+.card__description:empty {
+  display: none;
+}
+
+.card__meta {
+  margin: 0.7rem 0 0;
+  color: var(--accent);
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
+}
+
+.empty {
+  padding: 3rem 0;
+  color: var(--muted);
+  text-align: center;
+}
+
+.footer {
+  padding: 2rem 1.25rem 3rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.footer p {
+  margin: 0.35rem 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    transition: none;
+  }
+
+  .card:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
**Submission type:** New Miscellaneous (repository infrastructure — this PR adds no list entry)

## Preview

**https://tkoyama010.github.io/awesome-vtk/pr-preview/pr-177/** — this pull request, deployed.

## What

Publishes the awesome list as a browsable card gallery on GitHub Pages, and gives every pull request a preview of it.

`README.md` stays the single source of truth. `build_gallery.py` parses every `##` section into cards and renders a static site, so a new list entry appears on the site as soon as it lands on `main` — nothing is maintained twice.

- **Gallery cards** — one card per entry with its name, description and host. GitHub repository links get a real preview image from GitHub's Open Graph service; everything else (itk.org, docs.vtk.org, gitlab.kitware.com, …) falls back to a coloured monogram tile, so the grid stays even.
- **Search and filter** — live text search across name, description and category, plus one chip per category.
- **Light and dark** — follows the visitor's `prefers-color-scheme`.

## Pull request previews

| Pull request from | What the reviewer gets |
| --- | --- |
| a branch in this repository | A live URL, `…/pr-preview/pr-<N>/`, posted as a comment and updated on every push. Removed when the pull request closes. |
| a fork | The `gallery-preview` artifact, downloadable from the run summary. A fork's token is read only, so it cannot deploy anywhere — and giving it a write token would mean running a contributor's build with write access to this repository. |

Since GitHub Pages serves from a single source, the previews and the production site share the `gh-pages` branch: previews live under `pr-preview/`, and the production deploy passes `clean-exclude: pr-preview/` so publishing never deletes an open pull request's preview.

Branch deployment rather than the `github-pages` Actions environment is what makes the preview URLs possible — `actions/deploy-pages` has a native `preview` input, but it is alpha and not available publicly.

## Files

| File | Purpose |
| --- | --- |
| `build_gallery.py` | Parses `README.md` and writes the site (`--readme`, `--template-dir`, `--output`) |
| `site/index.html` | Page template with `{{FILTERS}}` / `{{SECTIONS}}` / count placeholders |
| `site/style.css`, `site/app.js` | Styling and the client side search / filter |
| `.github/workflows/pages.yaml` | Builds, deploys `main`, deploys and removes pull request previews |
| `.github/workflows/awesome_bot.yaml` | White lists the not-yet-published Pages URL |
| `README.md` | Links to the gallery |
| `.gitignore` | Ignores the build output and the `node_modules` cache prettier creates |

## Repository settings

Already done: Pages is enabled and serving from the `gh-pages` branch, root folder, which is why the preview link above works.

The site root, https://tkoyama010.github.io/awesome-vtk/, still returns 404 — only `pr-preview/pr-177/` exists on that branch so far. It starts working when this pull request merges and the `deploy` job publishes to the branch root. The README already links to it, so `tkoyama010.github.io` was added to the `awesome_bot` white list to keep the link check green in the meantime.

## Verification

- `uv run python build_gallery.py` emits 39 cards in 11 sections, matching the 39 `- [...]` entries under `##` headings in `README.md` (the doctoc table of contents is skipped).
- Entries without a description (the whole `Official` section) and non-GitHub links render correctly.
- Search, category chips and the empty state were exercised in a headless browser: `fortran` → 2 cards / 1 section, `Python` chip → 10 cards, a nonsense query → "No entry matches your search."
- Rendered and reviewed in both light and dark colour schemes.
- The preview deploy is confirmed end to end: the URL above returns 200 and contains all 39 cards.
- `pre-commit run --all-files` passes, `zizmor` and `check-github-workflows` included.
- Permissions are declared per job: the build job is `contents: read`, and only the deploy and preview jobs get write access.

### Not yet exercised

The `deploy` job is gated on `refs/heads/main`, so it has been skipped on every run and cannot be tested before merge. After merging, worth confirming:

- [ ] https://tkoyama010.github.io/awesome-vtk/ returns the gallery.
- [ ] `pr-preview/` still exists on the `gh-pages` branch, i.e. `clean-exclude` did its job.
- [ ] `preview-cleanup` ran for this pull request and removed `pr-preview/pr-177/`.

## Checklist for all pull requests:

- [x] Checked spelling and grammar.
- [x] Removed trailing whitespace and periods.

The remaining checklist items concern adding an entry to the list (certified awesome, duplicate search, single addition, category placement, icons, title casing). They are not applicable here: this PR adds the tooling that renders the list, not an entry in it.
