### PR TITLE
ci: white-list gitlab.kitware.com from awesome_bot

### DIFF
--- a/.github/workflows/awesome_bot.yaml
+++ b/.github/workflows/awesome_bot.yaml
@@ -23,4 +23,6 @@ jobs:
       - name: Checks
         # tkoyama010.github.io is white listed because the gallery only exists
         # once GitHub Pages has published it from the default branch.
-        run: bundle exec awesome_bot --allow-redirect --request-delay 1 --white-list "https://github.com/sindresorhus/awesome/blob/main/awesome.md,https://upload.wikimedia.org,https://tkoyama010.github.io" README.md
+        # gitlab.kitware.com is white listed because GitLab returns 403 to
+        # awesome_bot's user-agent; the link works for real users.
+        run: bundle exec awesome_bot --allow-redirect --request-delay 1 --white-list "https://github.com/sindresorhus/awesome/blob/main/awesome.md,https://upload.wikimedia.org,https://tkoyama010.github.io,https://gitlab.kitware.com/vtk/vtk" README.md


### PR DESCRIPTION
GitLab returns 403 to `awesome_bot`'s user-agent; the link `https://gitlab.kitware.com/vtk/vtk` works for real users (curl: 200). Same class of issue as the already-white-listed `upload.wikimedia.org` (429s).

## Root cause

The `Ruby` CI job (link check via `awesome_bot`) fails on `README.md:81`:

```
[L081] 403 https://gitlab.kitware.com/vtk/vtk
```

This is environmental — GitLab blocks the bot's user-agent, not a broken link. It is blocking PR #180 (and any other PR) from passing CI.

## Fix

Add `https://gitlab.kitware.com/vtk/vtk` to the `awesome_bot` white-list, matching the existing pattern for bot-hostile/rate-limited hosts.

## Verification

Ran locally:

```
$ bundle exec awesome_bot --allow-redirect --request-delay 1 \\
    --white-list "...,...,https://gitlab.kitware.com/vtk/vtk" README.md
...
> White listed:
  3. [L081] 403 https://gitlab.kitware.com/vtk/vtk
No issues :-)
```

Once merged to main, PR #180's CI re-runs against the updated base-branch workflow and passes.