### PR TITLE
Fix TTK link to point at the source repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 - [PyVista](https://github.com/pyvista/pyvista) - 3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit (VTK)
 - [SpinView](https://github.com/MXJK851/SpinView) - SpinView: General interactive visual analysis tool for multi-scale computational magnetism
 - [Trame](https://github.com/Kitware/trame) - Trame lets you weave various components and technologies into a Web Application solely written in Python.
-- [TTK](https://github.com/topology-tool-kit) - Topological Data Analysis and Visualization
+- [TTK](https://github.com/topology-tool-kit/ttk) - Topological Data Analysis and Visualization
 - [vedo](https://github.com/marcomusy/vedo) - A python module for scientific analysis of 3D data based on VTK and Numpy
 - [vtkbool](https://github.com/zippy84/vtkbool) - A new boolean operations filter for VTK
 


### PR DESCRIPTION
**Project name:** TTK (Topology ToolKit)

**Project website/repository:** https://github.com/topology-tool-kit/ttk

**License:** BSD-3-Clause (unchanged; this PR only updates the URL)

**Submission type:** Fix/update existing entry

## Checklist for all pull requests:

- [x] Project is [`certified awesome`](awesome.md)
- [x] The project is [open-source](https://opensource.org/licenses/alphabetical) and accessible.
- [x] Searched the existing entries to make sure this is not a duplicate.
- [x] Contains only a single addition (make separate PRs if adding more than one).
- [x] Added the link to the bottom of the relevant category.
- [x] Created a new category only if necessary.
- [x] Add icon from the `media/icon/` folder if applicable (e.g., `![Python](media/icon/python.png)` ).
- [x] Checked spelling and grammar.
- [x] Removed trailing whitespace and periods.
- [x] Confirm the dash – is not a minus -.
- [x] Used [title-casing](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case) (AP style) for project name.

### Checklist for new software projects:

Not applicable (URL-only update of an existing entry).

## Summary

The Python section currently links TTK to https://github.com/topology-tool-kit, which is the GitHub profile for the Topology ToolKit account, not the source repository.

This PR changes that URL to https://github.com/topology-tool-kit/ttk.

## Why this might have been intentional

I considered leaving the profile URL as-is. That account hosts more than the main codebase:

- [ttk](https://github.com/topology-tool-kit/ttk) — source (this change)
- [ttk-data](https://github.com/topology-tool-kit/ttk-data) — example data
- [ttk-paraview](https://github.com/topology-tool-kit/ttk-paraview) — custom ParaView tree
- [topology-tool-kit.github.io](https://github.com/topology-tool-kit/topology-tool-kit.github.io) — website

If the original link was meant as a hub for the whole TTK project family, the profile URL would make sense.

## Why I still think the repository is the better target

- The list item is named TTK and described as "Topological Data Analysis and Visualization", which matches the source repo, not the account.
- The pull request template asks to link the code repository rather than the website or documentation.
- Other entries in the same section (PyVista, vedo, Trame, and so on) point at a specific repository, not an org/profile page.
- The gallery builder only attaches a GitHub Open Graph thumbnail when the URL matches `github.com/owner/repo`. The profile URL currently gets no preview image.

Happy to revert if you prefer the profile URL as a hub. This is a one-line URL change; the description is untouched.
