### PR TITLE
Add K3D-jupyter to Jupyter

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 ## Jupyter
 
 - [jupyterview](https://github.com/trungleduc/jupyterview) - VTK Data visualization extension for JupyterLab
+- [K3D-jupyter](https://github.com/K3D-tools/K3D-jupyter) - WebGL 3D plotting for Jupyter, renders VTK objects alongside meshes, volumes, voxels and point clouds
 
 ## Large Language Model
 


### PR DESCRIPTION
**Project name:** K3D-jupyter

**Project website/repository:** https://github.com/K3D-tools/K3D-jupyter (docs: https://k3d-jupyter.org)

**License:** MIT

**Submission type:** New Software Project

## Checklist for all pull requests:

- [x] Project is `certified awesome`
- [x] The project is open-source and accessible.
- [x] Searched the existing entries to make sure this is not a duplicate. — `grep -in k3d README.md` returns nothing.
- [x] Contains only a single addition (make separate PRs if adding more than one).
- [x] Added the link to the bottom of the relevant category. — last line of `## Jupyter`, after `jupyterview`.
- [x] Created a new category only if necessary. — no new category.
- [ ] Add icon from the `media/icon/` folder if applicable — **N/A for this list:** the README has 0 `media/icon` references and the `media/` directory does not exist in this repo.
- [x] Checked spelling and grammar.
- [x] Removed trailing whitespace and periods.
- [ ] Confirm the dash – is not a minus - — **left as an ASCII hyphen on purpose: your `build_gallery.py` entry regex requires `\s+-\s+`, so an en-dash entry does not match it at all and would be dropped from the generated gallery. All 35 existing entries use the hyphen and the README contains 0 en-dashes. Evidence below; say the word and I will switch it.**
- [x] Used title-casing (AP style) for project name. — "K3D-jupyter" is the project's own capitalisation.

### Checklist for new software projects:

- [x] Link the code repository rather than the website/documentation
- [x] Installation instructions present — `pip install k3d` / `conda install -c conda-forge k3d`, both on the README and the docs.
- [x] Tests and CI running — pytest suite plus a visual-regression suite in GitHub Actions.

---

### About the entry

WebGL 3D plotting widget for Jupyter: meshes, isosurfaces, volumes, voxels, point clouds and streamlines, from plain NumPy arrays. ~1k stars, ~92k PyPI downloads/month, 237k on conda-forge.

Relevant to *this* list specifically because it renders **VTK objects directly** — `vtkPolyData` and friends go in without a conversion step. Since 3.0.0 the front end is an [anywidget](https://anywidget.dev), so the same package works in JupyterLab, Notebook, Colab and VS Code with no extension to enable.

### The one unchecked formatting box, with evidence

The template asks to confirm the dash is an en-dash rather than a hyphen. I used an ASCII hyphen on purpose, because on this list the en-dash would silently break the entry:

- `build_gallery.py` parses entries with
  `^-\s+\[(?P<name>[^\]]+)\]\((?P<url>[^)\s]+)\)(?:\s+-\s+(?P<description>.+?))?\s*$`
  — that `\s+-\s+` is an ASCII hyphen. I ran this regex against both variants of my line: the hyphen form matches and `name`/`description` parse; the en-dash form **does not match at all**, so the entry would be dropped from the generated gallery rather than merely lose its description.
- The README today contains **0** U+2013 characters and **35** occurrences of `) - `, so every existing entry uses the hyphen.

Both that box and the `media/icon` box look like they were inherited from a sibling list that genuinely uses en-dashes and icon badges. Happy to switch to an en-dash if you would rather the template be followed literally, but the gallery build would need the regex widened to `[-–]` first — feel free to treat this as a small bug report either way.

Two other things I checked so you do not have to:

- The `sort-markdown-list` pre-commit hook sorts each bullet block by the full lowercased line. `- [jupyterview]…` < `- [k3d-jupyter]…`, so the entry is already in sorted position and the hook is a no-op on this diff.
- The URL is a bare `owner/repo` GitHub link, so it also matches `GITHUB_REPO` and is thumbnail-eligible.

Disclosure: I maintain K3D-jupyter.
